### PR TITLE
fix(deps): security vulnerabilities in Gemfile.lock (faraday, concurrent-ruby, addressable, rexml)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    base64 (0.2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     bigdecimal (4.1.2)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.7)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     execjs (2.10.1)
-    faraday (2.8.1)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
+    google-protobuf (4.35.1)
+      bigdecimal
+      rake (~> 13.3)
     google-protobuf (4.35.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
@@ -53,6 +56,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.21.1)
     katex (0.11.0)
       execjs (~> 2.8)
     kramdown (2.4.0)
@@ -66,34 +70,39 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.1.1)
+    public_suffix (7.0.5)
     rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.6)
-      strscan
+    rexml (3.4.4)
     rouge (4.3.0)
-    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
+    sass-embedded (1.101.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
     sass-embedded (1.101.0-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
+    uri (1.1.1)
     webrick (1.8.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## Summary

Resolves 9 open Dependabot security advisories in `Gemfile.lock` (Ruby/Jekyll
dependency tree) via a scoped lockfile refresh:

`bundle lock --update faraday concurrent-ruby addressable rexml`

> Note: GitHub Issues is disabled on this repository, so no tracking issue was
> created for this remediation.

## Version Resolution

| Gem | Prior version | fix_version (specified) | Resolved version | Ecosystem |
|-----|---------------|--------------------------|------------------|-----------|
| faraday | 2.8.1 | 2.14.3 | 2.14.3 | rubygems |
| concurrent-ruby | 1.3.4 | 1.3.7 | 1.3.7 | rubygems |
| addressable | 2.8.7 | 2.9.0 | 2.9.0 | rubygems |
| rexml | 3.3.6 | 3.4.2 | 3.4.4 | rubygems |

Legitimate transitive bumps pulled in by the fixes (no manifest change):
- faraday 2.14.3 → faraday-net_http 3.4.4, json 2.21.1, logger 1.7.0, net-http 0.9.1, uri 1.1.1
- addressable 2.9.0 → public_suffix 7.0.5

## CVEs Fixed

- CVE-2026-54297 (faraday, high)
- CVE-2026-54904 (concurrent-ruby, high)
- CVE-2026-35611 (addressable, high)
- CVE-2026-25765 (faraday, moderate)
- CVE-2024-49761 (rexml, moderate)
- CVE-2026-54905 (concurrent-ruby, low)
- CVE-2026-54906 (concurrent-ruby, low)
- CVE-2026-33637 (faraday, low)
- CVE-2025-58767 (rexml, low)

## Verification

- `bundler-audit check` → **No vulnerabilities found**
- Old vulnerable versions confirmed absent from `Gemfile.lock`
- No macOS/`arm64-darwin` platform churn introduced (lockfile targets `ruby` + `x86_64-linux`)

## Not Run

- The Jekyll build test gate (`jekyll build`) could not be executed locally
  because the Linux-native gems (`sass-embedded`, `google-protobuf`) are not
  installed on this macOS machine. CI performs the actual build. The lockfile
  passed `bundler-audit` and integrity checks.
